### PR TITLE
Implemented puzzle patch (Agon Wastes - Portal Terminal) to revert th…

### DIFF
--- a/open_prime_rando/echoes/specific_area_patches.py
+++ b/open_prime_rando/echoes/specific_area_patches.py
@@ -2,12 +2,13 @@ import logging
 
 from construct import Container
 
-from open_prime_rando.echoes.asset_ids.agon_wastes import MINING_STATION_B_MREA
+from open_prime_rando.echoes.asset_ids.agon_wastes import MINING_STATION_B_MREA, PORTAL_TERMINAL_MREA
 from open_prime_rando.echoes.asset_ids.torvus_bog import TORVUS_ENERGY_CONTROLLER_MREA, TORVUS_TEMPLE_MREA
 from open_prime_rando.echoes.asset_ids.world import TORVUS_BOG_MLVL
 from open_prime_rando.patcher_editor import PatcherEditor
 from retro_data_structures.formats.script_object import ScriptInstanceHelper
 from retro_data_structures.game_check import Game
+from retro_data_structures.properties.echoes.objects.Counter import Counter
 from retro_data_structures.properties.echoes.objects.Relay import Relay
 from retro_data_structures.properties.echoes.objects.ScriptLayerController import ScriptLayerController
 
@@ -95,3 +96,33 @@ def torvus_temple_crash(editor: PatcherEditor):
     # for obj in ["GibFlash", "Sound - Swamp Crate Gib"] + debris:
     #     default.remove_instance(obj)
 
+
+def agon_wastes_portal_terminal_puzzle_patch(editor: PatcherEditor):
+    """
+    Patches Agon Wastes - Portal Terminal to behave like in GC NTSC-U/PAL
+    In GC NTSC-J version a counter was added to check for each cork to be broken
+    """
+    area = editor.get_mrea(PORTAL_TERMINAL_MREA)
+
+    """
+    Remove counter increment on the 2 first corks to destroy
+    """
+    relay_ids = [0x12033A, 0x120343]  # 0x120307 is the last cork to destroy
+    for relay_id in relay_ids:
+        relay = area.get_instance(relay_id)
+
+        properties = relay.get_properties()
+        assert isinstance(properties, Relay)
+        relay.remove_connections([0x12044E])
+        relay.set_properties(properties)
+
+    """
+    Set the destroyed cork counter to expect only one cork to be destroyed
+    """
+    counter = area.get_instance(0x12044E)
+
+    assert isinstance(counter.get_properties(), Counter)
+    properties = counter.get_properties_as(Counter)
+    properties.editor_properties.unknown = 1
+    properties.max_count = 1
+    counter.set_properties(properties)


### PR DESCRIPTION
# Implemented puzzle patch (Agon Wastes - Portal Terminal) to revert the fix added in NTSC-J and later

The fix added in NTSC-J and later forces the player to destroy the 3 corks to activate the portal.
This patch simulates the old behavior by removing the counter increment in the 2 first relays linked to the 2 first corks.
Also it makes the counter expects only one cork to be destroyed and since we don't delete the counter increment on the third cork, then it works like on GC NTSC-U/PAL.

This patch applies only on the following versions :
- GC NTSC-J
- Wii NTSC-J
- Wii NTSC-U
- Wii PAL