### PR TITLE
fix seeker doors being a little too persistent

### DIFF
--- a/open_prime_rando/echoes/dock_lock_rando/dock_type.py
+++ b/open_prime_rando/echoes/dock_lock_rando/dock_type.py
@@ -385,6 +385,9 @@ class SeekerBlastShieldDoorType(VanillaBlastShieldDoorType):
 
         for trigger in triggers:
             actors.relay.add_connection(State.Active, Message.Deactivate, trigger)
+        actors.relay.add_connection(State.Active, Message.Deactivate, mini_trigger)
+        actors.relay.add_connection(State.Active, Message.Deactivate, timer)
+        actors.relay.add_connection(State.Active, Message.Deactivate, timer_reset)
 
 
     def remove_blast_shield(self, editor: PatcherEditor, world_name: str, area_name: str, dock_name: str):


### PR DESCRIPTION
failing to deactivate the mini damageabletrigger when the memory relay is active meant it could respawn the others and force the player to re-destroy an invisible seeker door to proceed