### PR TITLE
Main Research changes

### DIFF
--- a/src/open_prime_rando/echoes/specific_area_patches/required_fixes.py
+++ b/src/open_prime_rando/echoes/specific_area_patches/required_fixes.py
@@ -15,6 +15,7 @@ from retro_data_structures.properties.echoes.objects import (
     Relay,
     ScriptLayerController,
     SpawnPoint,
+    StreamedAudio,
     Switch,
     Timer,
     Trigger,
@@ -133,22 +134,21 @@ def main_research(editor: PatcherEditor, mlvl: Mlvl, area: Area) -> None:
     relays = ((0x0B02E6, 0x0B02DE), (0x0B0303, 0x0B030D), (0x0B02F6, 0x0B02FA))
     _patch_echo_gate_softlock(area, 0x0B0315, relays)
 
+    # Make layer be inactive by default
     area.get_layer("Contraption").active = False
-    portal_spawn = area.get_instance(0x0B0056)
-    spawn_xfm = portal_spawn.get_properties_as(SpawnPoint).editor_properties.transform
-
-    contraption_controller = area.get_layer("Default").add_instance_with(
-        ScriptLayerController(
-            editor_properties=EditorProperties(name="Dynamic Increment Contraption", transform=spawn_xfm),
-            layer=LayerSwitch(
-                area_id=sanctuary_fortress.MAIN_RESEARCH_INTERNAL_ID, layer_number=area.get_layer("Contraption").index
-            ),
-            is_dynamic=True,
-        )
-    )
+    # Rename this existing object
+    contraption_layer_switch = area.get_instance("DYNAMIC Decrement Contraption")
+    with contraption_layer_switch.edit_properties(ScriptLayerController) as layer_switch:
+        layer_switch.editor_properties.name = "DYNAMIC Increment / Decrement Contraption"
+    # Add new Controller for the Spider Ball stuff, this layer
+    # gets incremented in Staging Area already but for room
+    # rando purposes, dynamically increment here as well
     spider_controller = area.get_layer("Default").add_instance_with(
         ScriptLayerController(
-            editor_properties=EditorProperties(name="Dynamic Increment Column Spiderball", transform=spawn_xfm),
+            editor_properties=EditorProperties(
+                name="Dynamic Increment Column Spiderball",
+                transform=Transform(position=Vector(-18.5, 150.6, -134.7), scale=Vector(2.0, 2.0, 2.0)),
+            ),
             layer=LayerSwitch(
                 area_id=sanctuary_fortress.MAIN_RESEARCH_INTERNAL_ID,
                 layer_number=area.get_layer("Column Spiderball").index,
@@ -156,10 +156,50 @@ def main_research(editor: PatcherEditor, mlvl: Mlvl, area: Area) -> None:
             is_dynamic=True,
         )
     )
-
-    for controller in (contraption_controller, spider_controller):
-        portal_spawn.add_connection(State.Arrived, Message.Load, controller)
-        controller.add_connection(State.Arrived, Message.Play, controller)
+    # Same issue as previous layer controller
+    first_pass_controller = area.get_layer("Default").add_instance_with(
+        ScriptLayerController(
+            editor_properties=EditorProperties(
+                name="Dynamic Decrement 1st Pass Enemies",
+                transform=Transform(position=Vector(-20, 150.6, -134.7), scale=Vector(2.0, 2.0, 2.0)),
+            ),
+            layer=LayerSwitch(
+                area_id=sanctuary_fortress.MAIN_RESEARCH_INTERNAL_ID,
+                layer_number=area.get_layer("1st Pass Enemies").index,
+            ),
+            is_dynamic=True,
+        )
+    )
+    # Define objects
+    portal_spawn = area.get_instance(0xB0056)
+    initial_spiderball_trigger = area.get_instance(0xB015B)
+    short_battle_sAudio = area.get_instance("Short Battle (INACTIVE)")
+    demo_contraption_trigger = area.get_instance("Start Demo Contraption")
+    contraption_encounter_trigger = area.get_instance("Start Contraption Encounter")
+    memory_relay = area.get_instance("Unlock 0l")
+    # These objects get activated/deactivated upon lower portal spawn
+    # arrival, but since the layer they're from gets incremented dynamically
+    # upon spawn they won't receive said messages, so we're updating their
+    # default status from the start
+    with initial_spiderball_trigger.edit_properties(Trigger) as trigger1:
+        trigger1.editor_properties.active = True
+    with short_battle_sAudio.edit_properties(StreamedAudio) as sAudio:
+        sAudio.editor_properties.active = True
+    with demo_contraption_trigger.edit_properties(Trigger) as trigger2:
+        trigger2.editor_properties.active = False
+    with contraption_encounter_trigger.edit_properties(Trigger) as trigger3:
+        trigger3.editor_properties.active = True
+    # Activate/Deactivate layers upon lower portal arrival
+    portal_spawn.add_connection(State.Zero, Message.Decrement, first_pass_controller)
+    portal_spawn.add_connection(State.Zero, Message.Increment, spider_controller)
+    portal_spawn.add_connection(State.Zero, Message.Increment, contraption_layer_switch)
+    spider_controller.add_connection(State.Arrived, Message.Play, spider_controller)
+    contraption_layer_switch.add_connection(State.Arrived, Message.Play, contraption_layer_switch)
+    # Make memory relay deactivate controller objects
+    # so the caretaker stuff doesn't load again
+    memory_relay.add_connection(State.Active, Message.Deactivate, contraption_layer_switch)
+    memory_relay.add_connection(State.Active, Message.Deactivate, spider_controller)
+    memory_relay.add_connection(State.Active, Message.Deactivate, first_pass_controller)
 
 
 @decorate_patcher(TEMPLE_GROUNDS_MLVL, temple_grounds.HIVE_CHAMBER_B_MREA)


### PR DESCRIPTION
Make the "Contraption" layer be inactive by default and dynamically load it upon lower spawn arrival. This patch already existed but it was incomplete, now it works properly.