### PR TITLE
README: add standalone patcher usage example for issue #133

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # Open Prime Rando
 Open Source randomizer patcher for Prime 2 and eventually 3.
 
+## Standalone patcher usage
+
+After installing the package, run the standalone CLI with the `echoes` game target and `randomizer` command:
+
+```bash
+open-prime-rando echoes \
+  --input-iso <path/to/input.iso> \
+  --output-iso <path/to/output.iso> \
+  randomizer \
+  --input-json <path/to/config.json>
+```
+
 
 
 # Credits


### PR DESCRIPTION
This PR adds a short **Standalone patcher usage** section to \.

It provides a concrete command example for running the standalone CLI (`open-prime-rando echoes ... randomizer --input-json ...`) so users can run the patcher without digging through source.

Addresses https://github.com/randovania/open-prime-rando/issues/133.

Checks run:
- Confirmed auth/login and fork visibility.
- Confirmed issue #133 is open and upstream repo is public.
- Documentation-only change; no runtime code paths changed, so no test suite was run.

Residual uncertainty:
- No visible CONTRIBUTING/CODE_OF_CONDUCT/issue-template files were found in the default-branch tree during API preflight checks.