### PR TITLE
Improve workflow for updating hashes

### DIFF
--- a/.github/workflows/update_hashes.yml
+++ b/.github/workflows/update_hashes.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+      issues: write
 
     steps:
       - name: Get PR branch and verify permissions
@@ -50,9 +51,40 @@ jobs:
         run: uv run pytest --update-hashes
 
       - name: Commit and push updated hashes
+        id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add tests/test_files/ntsc_hashes.json tests/test_files/pal_hashes.json tests/test_files/legacy_ntsc_hashes.json
-          git diff --staged --quiet || git commit -m "Update hash files"
-          git push
+          if git diff --staged --quiet; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "Update hash files"
+            git push
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Comment success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const changed = '${{ steps.commit.outputs.changed }}' === 'true';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: changed ? 'Hash files updated and pushed to this PR.' : 'No hash changes were needed.',
+            });
+
+      - name: Comment failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Failed to update hashes. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.`,
+            });

--- a/.github/workflows/update_hashes.yml
+++ b/.github/workflows/update_hashes.yml
@@ -1,0 +1,51 @@
+name: Update Hashes
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  update-hashes:
+    if: >
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/update-hashes' &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: self-hosted
+
+    permissions:
+      contents: write
+      pull-requests: read
+
+    steps:
+      - name: Get PR branch
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('head_ref', pr.data.head.ref);
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.head_ref }}
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Install dependencies
+        run: uv sync --locked --all-extras
+
+      - name: Run pytest --update-hashes
+        run: uv run pytest --update-hashes
+
+      - name: Commit and push updated hashes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add tests/test_files/ntsc_hashes.json tests/test_files/pal_hashes.json tests/test_files/legacy_ntsc_hashes.json
+          git diff --staged --quiet || git commit -m "Update hash files"
+          git push

--- a/.github/workflows/update_hashes.yml
+++ b/.github/workflows/update_hashes.yml
@@ -8,8 +8,7 @@ jobs:
   update-hashes:
     if: >
       github.event.issue.pull_request &&
-      github.event.comment.body == '/update-hashes' &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      github.event.comment.body == '/update-hashes'
     runs-on: self-hosted
 
     permissions:
@@ -17,11 +16,19 @@ jobs:
       pull-requests: read
 
     steps:
-      - name: Get PR branch
+      - name: Get PR branch and verify permissions
         id: pr
         uses: actions/github-script@v7
         with:
           script: |
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            if (!['admin', 'write'].includes(perm.permission)) {
+              core.setFailed(`${context.actor} does not have write access`);
+            }
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/README.md
+++ b/README.md
@@ -3,6 +3,33 @@ Open Source randomizer patcher for Prime 2 and eventually 3.
 
 
 
+# Updating hash files
+
+Some tests compare the output of the patcher against pre-recorded hash files. When a code change intentionally alters the output, these files need to be regenerated.
+
+## Setup
+
+The tests require ISO files for Metroid Prime 2: Echoes. Create a `.env` file in the repository root:
+
+```
+PRIME2_ISO=/path/to/prime2_ntsc.iso
+PRIME2_PAL_ISO=/path/to/prime2_pal.iso
+```
+
+> These can also be set as regular environment variables instead of using `.env`.
+
+## Running locally
+
+```sh
+uv run pytest --update-hashes -n 2
+```
+
+This runs only the hash-comparison tests and writes the new hashes in place of the old ones.
+
+## Via GitHub (pull requests)
+
+Anyone with write access to the repository can comment `/update-hashes` on a pull request. A workflow will run the tests on the self-hosted runner, commit the updated files, and push them to the PR branch.
+
 # Credits
 
 # Echoes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,24 @@ from retro_data_structures.game_check import Game
 
 from open_prime_rando.patcher_editor import IsoFileWriter, PatcherEditor
 
+_REPO_ROOT = Path(__file__).parent.parent
+_DOT_ENV: dict[str, str] | None = None
+
+
+def _load_dot_env() -> dict[str, str]:
+    global _DOT_ENV  # noqa: PLW0603
+    if _DOT_ENV is None:
+        _DOT_ENV = {}
+        dot_env_path = _REPO_ROOT / ".env"
+        if dot_env_path.exists():
+            for raw_line in dot_env_path.read_text().splitlines():
+                stripped = raw_line.strip()
+                if stripped and not stripped.startswith("#") and "=" in stripped:
+                    key, _, value = stripped.partition("=")
+                    _DOT_ENV[key.strip()] = value.strip()
+    return _DOT_ENV
+
+
 _FAIL_INSTEAD_OF_SKIP = True
 
 
@@ -63,12 +81,13 @@ def get_env_or_skip(env_name: str, override_fail: bool | None = None) -> str:
         fail_or_skip = _FAIL_INSTEAD_OF_SKIP
     else:
         fail_or_skip = override_fail
-    if env_name not in os.environ:
+    value = os.environ.get(env_name) or _load_dot_env().get(env_name)
+    if value is None:
         if fail_or_skip:
             pytest.fail(f"Missing environment variable {env_name}")
         else:
             pytest.skip(f"Skipped due to missing environment variable {env_name}")
-    return os.environ[env_name]
+    return value
 
 
 class TestFilesDir:
@@ -132,8 +151,30 @@ def pytest_addoption(parser) -> None:
         default=True,
         help="Skip tests instead of missing, in case any asset is missing",
     )
+    parser.addoption(
+        "--update-hashes",
+        action="store_true",
+        dest="update_hashes",
+        default=False,
+        help="Update hash files instead of comparing; only runs test_ntsc_export, test_pal_export, and test_ntsc_paks",
+    )
 
 
 def pytest_configure(config: pytest.Config) -> None:
     global _FAIL_INSTEAD_OF_SKIP  # noqa: PLW0603
     _FAIL_INSTEAD_OF_SKIP = config.option.fail_if_missing
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list) -> None:
+    if not getattr(config.option, "update_hashes", False):
+        return
+
+    selected = [item for item in items if "update_hashes" in item.fixturenames]
+    deselected = [item for item in items if "update_hashes" not in item.fixturenames]
+    config.hook.pytest_deselected(items=deselected)
+    items[:] = selected
+
+
+@pytest.fixture(scope="session")
+def update_hashes(request) -> bool:
+    return bool(getattr(request.config.option, "update_hashes", False))

--- a/tests/echoes/test_legacy_patcher.py
+++ b/tests/echoes/test_legacy_patcher.py
@@ -4,7 +4,6 @@ import json
 from typing import TYPE_CHECKING
 from unittest.mock import ANY, MagicMock
 
-import pytest
 from retro_data_structures.game_check import Game
 
 from open_prime_rando.dol_patching.echoes import dol_versions
@@ -29,14 +28,17 @@ def hash_all_paks(base_path: Path, hash_util: HashUtil) -> dict:
 
 def _update_hashes_file(path: Path, hashes: dict) -> None:
     path.write_text(json.dumps(hashes, indent=4))
-    pytest.fail("updated hashes file")
 
 
-def test_ntsc_paks(prime2_iso_provider, tmp_path, test_files_dir, hash_util: HashUtil) -> None:
+def test_ntsc_paks(
+    prime2_iso_provider,
+    tmp_path,
+    test_files_dir,
+    hash_util: HashUtil,
+    update_hashes: bool,
+) -> None:
     output_path = tmp_path.joinpath("out")
     configuration = test_files_dir.read_json("echoes", "door_lock.json")
-
-    expected_hashes = test_files_dir.read_json("legacy_ntsc_hashes.json")
 
     legacy_patcher.patch_paks(
         file_provider=prime2_iso_provider,
@@ -45,9 +47,11 @@ def test_ntsc_paks(prime2_iso_provider, tmp_path, test_files_dir, hash_util: Has
     )
     hashes = hash_all_paks(output_path, hash_util)
 
-    # _update_hashes_file(test_files_dir.joinpath("legacy_ntsc_hashes.json"), hashes)
-
-    assert hashes == expected_hashes
+    if update_hashes:
+        _update_hashes_file(test_files_dir.joinpath("legacy_ntsc_hashes.json"), hashes)
+    else:
+        expected_hashes = test_files_dir.read_json("legacy_ntsc_hashes.json")
+        assert hashes == expected_hashes
 
 
 def test_pal_paks(pal_prime2_iso_provider, tmp_path, test_files_dir):

--- a/tests/echoes/test_patcher.py
+++ b/tests/echoes/test_patcher.py
@@ -24,15 +24,18 @@ def configuration(test_files_dir):
 
 def _update_hashes_file(path: Path, hashes: dict[str, str | dict]) -> None:
     path.write_text(json.dumps(hashes, indent=4, sort_keys=True))
-    pytest.fail("updated hashes file")
 
 
-def test_ntsc_export(prime2_ntsc_iso_path, tmp_path, configuration, test_files_dir, hash_util: HashUtil) -> None:
+def test_ntsc_export(
+    prime2_ntsc_iso_path,
+    configuration,
+    test_files_dir,
+    hash_util: HashUtil,
+    update_hashes: bool,
+) -> None:
     file_provider = IsoFileProvider(prime2_ntsc_iso_path)
     editor = PatcherEditor(file_provider, Game.ECHOES)
     output = IsoFileWriter(file_provider)
-
-    expected_hashes = test_files_dir.read_json("ntsc_hashes.json")
 
     # Run
     patcher._apply_patches(editor, configuration, output)
@@ -40,26 +43,34 @@ def test_ntsc_export(prime2_ntsc_iso_path, tmp_path, configuration, test_files_d
     # Assert
     hashes = hash_util.hash_iso_file_writer(output)
 
-    # _update_hashes_file(test_files_dir.joinpath("ntsc_hashes.json"), hashes)
+    if update_hashes:
+        _update_hashes_file(test_files_dir.joinpath("ntsc_hashes.json"), hashes)
+    else:
+        expected_hashes = test_files_dir.read_json("ntsc_hashes.json")
+        assert hashes == expected_hashes
 
-    assert hashes == expected_hashes
 
-
-def test_pal_export(prime2_pal_iso_path, tmp_path, configuration, test_files_dir, hash_util: HashUtil) -> None:
+def test_pal_export(
+    prime2_pal_iso_path,
+    configuration,
+    test_files_dir,
+    hash_util: HashUtil,
+    update_hashes: bool,
+) -> None:
     configuration.practice_mod = PracticeModMode.disabled
 
     file_provider = IsoFileProvider(prime2_pal_iso_path)
     editor = PatcherEditor(file_provider, Game.ECHOES)
     output = IsoFileWriter(file_provider)
 
-    expected_hashes = test_files_dir.read_json("pal_hashes.json")
-
     # Run
     patcher._apply_patches(editor, configuration, output)
 
     # Assert
     hashes = hash_util.hash_iso_file_writer(output)
 
-    # _update_hashes_file(test_files_dir.joinpath("pal_hashes.json"), hashes)
-
-    assert hashes == expected_hashes
+    if update_hashes:
+        _update_hashes_file(test_files_dir.joinpath("pal_hashes.json"), hashes)
+    else:
+        expected_hashes = test_files_dir.read_json("pal_hashes.json")
+        assert hashes == expected_hashes


### PR DESCRIPTION
- Add a command line argument for updating hashes
- Using that argument runs only the hash tests
- Allow updating hashes from the PR by making a comment
- Add instructions to the README